### PR TITLE
Add support for Tiled 1.9 "class" attributes

### DIFF
--- a/src/nim_tiled.nim
+++ b/src/nim_tiled.nim
@@ -7,10 +7,8 @@ import
   strformat,
   os,
   tables,
-  ospaths,
   typeinfo,
   base64,
-  math,
   terminal,
   zippy
 
@@ -383,7 +381,7 @@ proc loadTileset*(theXml: XmlNode): TiledTileset =
         if shape != nil:
           tiledTile.collisionShapes.add shape
 
-    result.tiles.add(tileid, tiledTile)
+    result.tiles[tileid] = tiledTile
 
   let width = theImage.attr("width").parseInt
   let height = theImage.attr("height").parseInt

--- a/tests/test1.nim
+++ b/tests/test1.nim
@@ -1,6 +1,6 @@
 import ../src/nim_tiled
 import os
-import tables, typeinfo, base64
+import tables
 
 proc writeTiledToText(map: TiledMap): string=
   result = ""
@@ -34,5 +34,5 @@ doAssert(expected == writeTiledToText(loadTiledMap(getAppDir() & "/8x8Base64Zlib
 let map = loadTiledMap(getAppDir() & "/8x8ZlibEmbededTilesheet.tmx")
 doAssert(expected == writeTiledToText(map))
 doAssert(map.objectGroups[0].objects[0].name == "Lemon")
-doAssert(map.objectGroups[0].objects[0].objectType == "Tree")
+doAssert(map.objectGroups[0].objects[0].class == "Tree")
 doAssert(map.layers[0].properties["test"].valueString == "Hello World")

--- a/tests/test2.nim
+++ b/tests/test2.nim
@@ -1,6 +1,5 @@
 import ../src/nim_tiled
 import os
-import tables, typeinfo, base64
 
 let map = loadTiledMap(getAppDir() & "/8x8Csv.tmx")
 


### PR DESCRIPTION
Tiled 1.9 renamed the `type` attribute to `class` (see [Unified Custom Types](https://www.mapeditor.org/2022/06/25/tiled-1-9-released.html#unified-custom-types) in the release notes)

This PR adds support for the new attribute, falling back to `type` if `class` was not found. The `objectType` and `tileType` fields have also been renamed to `class`, and accessor procs have been introduced (with a deprecation notice) to avoid breaking old code.

Additionally, I've fixed some compiler warnings (unused imports, `tables.add` being deprecated).